### PR TITLE
/test now always returns in 30sec

### DIFF
--- a/clients/shared/hxml/git-libs.hxml
+++ b/clients/shared/hxml/git-libs.hxml
@@ -1,4 +1,4 @@
--lib hxnodelibs:git:https://github.com/dionjwa/hxnodelibs.git#0acfaef
+-lib hxnodelibs:git:https://github.com/dionjwa/hxnodelibs.git#e5f463a
 -lib hxnodejs-redis:git:https://github.com/dionjwa/hxnodejs-redis.git#3eef451
 -lib hxnodejs-redis-lua:git:https://github.com/dionjwa/hxnodejs-redis-lua.git#06fb878
 -lib haxe-misc-tools:git:https://github.com/dionjwa/haxe-misc-tools.git#689e2b1

--- a/src/haxe/ccc/compute/server/services/ws/ServiceWebsockets.hx
+++ b/src/haxe/ccc/compute/server/services/ws/ServiceWebsockets.hx
@@ -22,9 +22,9 @@ class ServiceWebsockets
 		_injector.map(WebSocketServer).toValue(_wss);
 
 		//Listen to websocket connections.
-		_wss.on(WebSocketServerEvent.Connection, function(ws) {
+		_wss.on(WebSocketServerEvent.Connection, function(ws :WebSocket, req) {
 
-			var url :String = Reflect.field(ws.upgradeReq, 'url');
+			var url :String = req.url;
 			Log.debug('Websocket connection request url=$url');
 			switch(url) {
 				case '/dashboard':

--- a/src/haxe/ccc/compute/shared/ServerConfig.hx
+++ b/src/haxe/ccc/compute/shared/ServerConfig.hx
@@ -42,7 +42,13 @@ class ServerConfig
 	 * Defaults to three minutes.
 	 */
 	@NodeProcessVar
-	public static var MONITOR_DEFAULT_JOB_COMPLETED_WITHIN :Int = 180;
+	public static var MONITOR_DEFAULT_JOB_COMPLETED_WITHIN_SECONDS :Int = 180;
+
+	/**
+	 * Monitor requests will always return within this time
+	 */
+	@NodeProcessVar
+	public static var MONITOR_TIMEOUT_SECONDS :Int = 30;
 
 	@NodeProcessVar
 	public static var PORT :Int = 9000;


### PR DESCRIPTION
/test now always returns in 30sec and checks active queue if no jobs are finished (configurable)

This fixes the logic hole where if the queue is full of long running jobs, the monitor will not have any finished jobs as evidence that the stack is healthy, nor will it be able to run test jobs (since the queue is full). 

So in these conditions, check that the number of active jobs is > 0, if so, the stack is healthy.